### PR TITLE
1.14.1 geoips_ci - version release - replace GEOIPS_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/brassy-notes.yaml
+++ b/.github/workflows/brassy-notes.yaml
@@ -22,4 +22,4 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proper-release-note-edits.yaml
+++ b/.github/workflows/proper-release-note-edits.yaml
@@ -11,6 +11,6 @@ jobs:
   note-edits:
     name: Note edits
     # You do not appear to be able to use variables in the "uses" field.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-proper-release-note-edits.yaml@v1.14.1-release
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-proper-release-note-edits.yaml@main
     permissions:
       contents: read

--- a/.github/workflows/tag-and-release.yaml
+++ b/.github/workflows/tag-and-release.yaml
@@ -22,4 +22,4 @@ jobs:
     permissions:
       contents: write
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/releases/latest/replace-geoips-token-with-github-token.yaml
+++ b/docs/source/releases/latest/replace-geoips-token-with-github-token.yaml
@@ -1,0 +1,25 @@
+GitHub Actions:
+- title: 'Replace GEOIPS_TOKEN with GITHUB_TOKEN'
+  description: |
+    *From NRLMMD-GEOIPS/geoips#740: 2024-10-01, 1.14.1 updates*
+
+    Replace GEOIPS_TOKEN with GITHUB_TOKEN so outside users do not have to
+    have a GEOIPS_TOKEN defined in order to use workflows.
+  files:
+    modified:
+    - .github/workflows/brassy-notes.yaml
+    - .github/workflows/tag-and-release.yaml
+    - sync/.github/workflows/brassy-notes.yaml
+    - sync/.github/workflows/deploy-docs.yaml
+    - sync/.github/workflows/lint.yaml
+    - sync/.github/workflows/package-and-publish.yaml
+    - sync/.github/workflows/tag-and-release.yaml
+    deleted:
+    - ''
+    added:
+    - ''
+    moved:
+    - ''
+  related-issue:
+    number: 740
+    repo_url: https://github.com/NRLMMD-GEOIPS/geoips

--- a/sync/.github/workflows/brassy-notes.yaml
+++ b/sync/.github/workflows/brassy-notes.yaml
@@ -22,4 +22,4 @@ jobs:
       contents: write
       pull-requests: write
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/sync/.github/workflows/deploy-docs.yaml
+++ b/sync/.github/workflows/deploy-docs.yaml
@@ -33,4 +33,4 @@ jobs:
     permissions:
       contents: write
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/sync/.github/workflows/lint.yaml
+++ b/sync/.github/workflows/lint.yaml
@@ -15,4 +15,4 @@ jobs:
     permissions:
       contents: read
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/sync/.github/workflows/package-and-publish.yaml
+++ b/sync/.github/workflows/package-and-publish.yaml
@@ -33,6 +33,6 @@ jobs:
     permissions:
       contents: read
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}
       pypi_user: ${{ secrets.PYPI_USER }}
       pypi_password: ${{ secrets.PYPI_PASSWORD }}

--- a/sync/.github/workflows/tag-and-release.yaml
+++ b/sync/.github/workflows/tag-and-release.yaml
@@ -22,4 +22,4 @@ jobs:
     permissions:
       contents: write
     secrets:
-      token: ${{ secrets.GEOIPS_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replacing GEOIPS_TOKEN with GITHUB_TOKEN in the workflows - also opening this PR so we can actually go through the tag/release process on geoips_ci repo when merged (now that the branch is named v*-version-release)