### PR TITLE
Update reusable-doc-test.yaml for bug fix in geoips#840 and geoips#850

### DIFF
--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -297,7 +297,7 @@ jobs:
           #   the path to the docs template directory in the geoips default branch.
           python3 $BASE_GEOIPS_PATH/docs/build_docs.py \
             --geoips-docs-path $BASE_GEOIPS_PATH/docs/ \
-            --force FORCE \
+            --force \
             --repo-path . \
             $run_on_package
           ret=$?

--- a/docs/source/releases/latest/build-docs-patch.yaml
+++ b/docs/source/releases/latest/build-docs-patch.yaml
@@ -1,0 +1,13 @@
+actions:
+- title: Call build_docs.py with corrected arguments
+  description: |
+    Change from using hotfix --force FORCE to just using correct --force now that build_docs.py has been fixed on GeoIPS core.
+  files:
+    modified:
+    - geoips_ci/.github/workflows/reusable-doc-test.yaml
+  date:
+    start: 2024-12-20
+    finish: 2024-12-20
+  related-issue:
+    number: 0
+    repo_url: ""


### PR DESCRIPTION
Fixes call argument for build_docs.py (from `--force FORCE` to just `--force`)