### PR TITLE
Update reusable-proper-release-note-edits.yaml

### DIFF
--- a/.github/workflows/reusable-proper-release-note-edits.yaml
+++ b/.github/workflows/reusable-proper-release-note-edits.yaml
@@ -107,8 +107,8 @@ jobs:
           fi
           echo "git -C $PWD/current_repo_current_branch fetch"
           git -C $PWD/current_repo_current_branch fetch
-          echo "git -C $PWD/current_repo_current_branch diff --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst"
-          ret=$(git -C $PWD/current_repo_current_branch diff --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst)
+          echo "git -C $PWD/current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst"
+          ret=$(git -C $PWD/current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst)
           for file in ${ret[@]}; do
               echo "    $file"
           done
@@ -149,11 +149,11 @@ jobs:
           # If this is the final release branch, then we are just moving release notes,
           # note modifying.  In that case, allow renamed as well as added or modified.
           if [[ ${{ needs.check-release-branch.outputs.IS_VERSION_RELEASE_BRANCH == 'true' }} ]]; then
-            echo "git -C ./current_repo_current_branch diff --name-only --diff-filter=RAM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml"
-            ret=$(git -C ./current_repo_current_branch diff --name-only --diff-filter=RAM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml)
+            echo "git -C ./current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=RAM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml"
+            ret=$(git -C ./current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=RAM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml)
           else
-            echo "git -C ./current_repo_current_branch diff --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml"
-            ret=$(git -C ./current_repo_current_branch diff --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml)
+            echo "git -C ./current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml"
+            ret=$(git -C ./current_repo_current_branch diff --ignore-space-at-eol --name-only --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.yaml)
           fi
           echo "Release note files modified this PR:"
           for file in ${ret[@]}; do

--- a/docs/source/releases/latest/9-change-ci-to-ignore-whitespace-at-eol-of-rst-release-notes.yaml
+++ b/docs/source/releases/latest/9-change-ci-to-ignore-whitespace-at-eol-of-rst-release-notes.yaml
@@ -1,0 +1,13 @@
+actions:
+- title: Ignore RST Whitespace
+  description: |
+    Ignores whitespace changes at the end of lines in rst release files.
+  files:
+    modified:
+    - .github/workflows/reusable-proper-release-note-edits.yaml
+  date:
+    start: 2024-12-30
+    finish: 2024-12-30
+  related-issue:
+    number: 9
+    repo_url: ""


### PR DESCRIPTION
Ignores whitespace changes at the end of lines on CI checking for edits to release note rst files.