### PR TITLE
Update reusable-proper-release-note-edits.yaml - remove stray ")"

### DIFF
--- a/.github/workflows/reusable-proper-release-note-edits.yaml
+++ b/.github/workflows/reusable-proper-release-note-edits.yaml
@@ -117,7 +117,7 @@ jobs:
           else
               echo ::group::Full Git Diff
               echo "git -C $PWD/current_repo_current_branch diff --ignore-space-at-eol --stat --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst"
-              git -C $PWD/current_repo_current_branch diff --ignore-space-at-eol --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst)
+              git -C $PWD/current_repo_current_branch diff --ignore-space-at-eol --diff-filter=AM remotes/origin/${target_ref} -- $release_notes_dir/*.rst
               echo ::endgroup::
               echo "FAILED: Release note changes detected"
               echo "Please use brassy to enter change logs in $release_notes_dir"


### PR DESCRIPTION
Removed stray ")" at end of line in reusable notes CI because it was a typo!