### PR TITLE
Adding CODEOWNERS file to sync directory

### DIFF
--- a/sync/.github/CODEOWNERS
+++ b/sync/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# More info:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cira-review and @nrl-review will be requested for
+# review when someone opens a pull request.
+*       @NRLMMD-GEOIPS/nrl-review


### PR DESCRIPTION
This only works for NRLMMD-GEOIPS org, but this is the NRLMMD-GEOIPS org sync folder