### PR TITLE
Build stable image on tag

### DIFF
--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -168,7 +168,12 @@ jobs:
           echo "runner os: ${{ runner.os }}"
           echo "github sha: ${{ github.sha }}"
           echo "build cache image: ${{ env.BUILDCACHE_IMAGE }}"
+          # Create stable image on default branch
           if [[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+            stableorlatest_image="${IMAGE_NAME}:doclinttest-stable"
+            tags="${tags},${stableorlatest_image}"
+          # Also create stable image on tag
+          elif [[ "${GITHUB_REF}" == "refs/tags/"* ]]; then
             stableorlatest_image="${IMAGE_NAME}:doclinttest-stable"
             tags="${tags},${stableorlatest_image}"
           else

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -220,6 +220,8 @@ jobs:
           docker push ${STABLEORLATEST_IMAGE};
       - name: Build and push docker image with docker buildx action
         if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
+        # References the below commit, which matched both v6 and v6.12.0 at the time
+        # of this writing.
         # https://github.com/docker/build-push-action/commit/67a2d409c0a876cbe6b11854e3e25193efe4e62d
         uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6 / v6.12.0
         with:

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -101,8 +101,8 @@ jobs:
           echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_ENV}
           echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_OUTPUT}
 
-  print-variables:
-    name: Print variables
+  print-build-image-variables:
+    name: Print build image variables
     needs: [get-job-flags]
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-print-variables.yaml@main

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -146,6 +146,8 @@ jobs:
 
       - name: Setup BuildX
         if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
+        # References the below commit, which matched both v3 and v3.8.0 at the time
+        # of this writing.
         # https://github.com/docker/setup-buildx-action/commit/6524bf65af31da8d45b59e8c27de4bd072b392f5
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3 / v3.8.0
 

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -1,0 +1,216 @@
+name: Build docker image
+
+on:
+  # Reusable workflow
+  workflow_call:
+    secrets:
+      token:
+        required: true
+      docker_token:
+        required: true
+
+# Assuming the below is in the workflow for an individual repository.
+# on:
+#   # triggers the workflow on published release
+#   release:
+#     types:
+#       - published
+#   # allows run of this workflow manually from the actions tab
+#   # must be merged to default before it will be available to manually run.
+#   workflow_dispatch:
+
+env:
+  # REQUIRED organization level variables used in this workflow.
+  #   ${{ github.event.repository.default_branch }} is used throughout
+  #     rather than main to generalize default branch
+  #     (removed DEFAULT_BRANCH org var)
+  #   DOCKER_REGISTRY: URL to the docker registry
+  #   DOCKER_REGISTRY_USER: user to sign into DOCKER_REGISTRY
+  #   DOCKER_REGISTRY_TOKEN: token for USER user to sign into DOCKER_REGISTRY
+  #   RUNNER: default runner
+  #   UPLOAD_GITHUB_ARTIFACTS: true/false, specify whether to upload artifacts to github
+  #   USE_DOCKER_BUILDX_ACTION: true/false, specify whether to use the docker buildx action
+
+  # OPTIONAL organization level variables:
+  #   # Some system implementations may require different runners for building and
+  #   # running docker containers - allow specifying separately. Defaults to vars.RUNNER
+  #   # if these are not defined. Note env context nor strings are supported in the
+  #   # runs-on field, so we MUST use the vars context for the default.
+  #   RUNNER_DOCKERBUILD: runner to build docker containers
+  #   RUNNER_DOCKERRUN: runner to run docker containers
+
+  # The path to the GeoIPS package in DOCLINTTEST images
+  BASE_GEOIPS_PATH: /packages/geoips
+  # Allow overriding the doclinttest image tag used for plugin packages
+  # Allows using a different version of the doc, lint, and test code
+  PLUGIN_DOCLINTTEST_TAG: doclinttest-stable
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Set variables that should be accessible to all jobs
+  get-job-flags:
+    runs-on: ${{ vars.RUNNER }}
+    env:
+      CURR_REPO: ${{ github.event.repository.name }}
+    outputs:
+      # The name of the untagged docker images to be created by this workflow
+      IMAGE_NAME: ${{ steps.set_image_name.outputs.IMAGE_NAME }}
+      REPO_NAME: ${{ steps.set_image_name.outputs.REPO_NAME }}
+      # The tag to use for the doclinttest images
+      DOCLINTTEST_TAG: ${{ steps.set_doclinttest_tag.outputs.DOCLINTTEST_TAG }}
+      # The image to use for doclinttest jobs
+      DOCLINTTEST_IMAGE: ${{ steps.set_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
+    steps:
+      - name: Set the image name
+        id: set_image_name
+        run: |
+          repo_name=$(echo ${{ github.repository }} | cut -d'/' -f2)
+          # Create an image name using the organiztion and repository names, lowercase
+          image_name=${{ vars.DOCKER_REGISTRY_USER }}/geoips
+          echo "REPO_NAME=${repo_name}"
+          echo "REPO_NAME=${repo_name}" >> ${GITHUB_ENV}
+          echo "REPO_NAME=${repo_name}" >> ${GITHUB_OUTPUT}
+          echo "IMAGE_NAME=${image_name}"
+          echo "IMAGE_NAME=${image_name}" >> ${GITHUB_ENV}
+          echo "IMAGE_NAME=${image_name}" >> ${GITHUB_OUTPUT}
+      - name: Set doclinttest image tag
+        id: set_doclinttest_tag
+        run: |
+          echo "CURR_REPO: ${CURR_REPO}"
+          # If the current repository is geoips, use the image we're about to build
+          # for running tests and building docs.
+          if [[ "${CURR_REPO}" == "geoips" ]]; then
+              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}"
+              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}" >> ${GITHUB_ENV}
+              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}" >> ${GITHUB_OUTPUT}
+          else
+              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}"
+              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}" >> ${GITHUB_ENV}
+              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}" >> ${GITHUB_OUTPUT}
+          fi
+      - name: Set doclinttest image
+        id: set_doclinttest_image
+        run: |
+          owner=${{ github.repository_owner }}
+          owner=${owner,,}
+          doclinttest_image_name=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}
+          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}"
+          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_ENV}
+          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_OUTPUT}
+
+  print-variables:
+    name: Print variables
+    needs: [get-job-flags]
+    # You do not appear to be able to use variables in this "uses" field.
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-print-variables.yaml@main
+    with:
+      # These are outputs defined above.  Explicitly pass them in here to track
+      # what variables we have available to this workflow.
+      IMAGE_NAME: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}
+      REPO_NAME: ${{ needs.get-job-flags.outputs.REPO_NAME }}
+      DOCLINTTEST_TAG: ${{ needs.get-job-flags.outputs.DOCLINTTEST_TAG }}
+      DOCLINTTEST_IMAGE: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+
+  # Build the base GeoIPS doclinttest image
+  # This image is used in all subsequent tests
+  # It is only built for the main GeoIPS package but is used by all repositories
+  #
+  # Within this image, the GeoIPS package is located in /packages/geoips and is
+  # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
+  # from /packages/geoips.
+  build_doclinttest_image:
+    runs-on: ${{ vars.RUNNER_DOCKERBUILD || vars.RUNNER }}
+    needs: get-job-flags
+    if: >
+      ! cancelled() &&
+      vars.USE_CONDA_FOR_ACTIONS != 'true' &&
+      github.event.repository.name == 'geoips'
+    env:
+      IMAGE_NAME: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}
+      BUILDCACHE_IMAGE: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}:buildcache
+      DOCLINTTEST_IMAGE: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+    # Can't write to registry without this
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup BuildX
+        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to the Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.DOCKER_REGISTRY }}
+          username: ${{ vars.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.docker_token }}
+
+      # This cache allows the second push below when on the default branch
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Create tags
+        run: |
+          tags="${DOCLINTTEST_IMAGE},${BUILDCACHE_IMAGE}"
+          echo "GITHUB REF: ${GITHUB_REF}"
+          echo "Default Branch: refs/heads/${{ github.event.repository.default_branch }}"
+          echo "runner os: ${{ runner.os }}"
+          echo "github sha: ${{ github.sha }}"
+          echo "build cache image: ${{ env.BUILDCACHE_IMAGE }}"
+          if [[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
+            stableorlatest_image="${IMAGE_NAME}:doclinttest-stable"
+            tags="${tags},${stableorlatest_image}"
+          else
+            stableorlatest_image="${IMAGE_NAME}:doclinttest-latest"
+            tags="${tags},${stableorlatest_image}"
+          fi
+          # PUSH_TAGS is used with the docker buildx action
+          echo "PUSH_TAGS=${tags}"
+          echo "PUSH_TAGS=${tags}" >> $GITHUB_ENV
+          # STABLEORLATEST_IMAGE is only used with the explicit docker build command.
+          # It is the full path to the stable or latest image tag.
+          # The explicit docker build command requires pushing each image separately
+          # to the registry - so we need to track the stable/latest tag in addition
+          # to the DOCLINTTEST_IMAGE and BUILDCACHE_IMAGE tags
+          echo "STABLEORLATEST_IMAGE=${stableorlatest_image}"
+          echo "STABLEORLATEST_IMAGE=${stableorlatest_image}" >> $GITHUB_ENV
+
+      # If using docker buildx was requested via organization variable,
+      # DO NOT run this section.
+      - name: Build and push docker image with explicit docker build
+        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'false' }}
+        # > makes newlines into spaces, so single command on multiple lines.
+        run: >
+          which docker;
+          docker build
+          --file Dockerfile
+          --tag ${DOCLINTTEST_IMAGE}
+          --tag ${BUILDCACHE_IMAGE}
+          --tag ${STABLEORLATEST_IMAGE}
+          --target doclinttest
+          .;
+          docker push ${BUILDCACHE_IMAGE};
+          docker push ${DOCLINTTEST_IMAGE};
+          docker push ${STABLEORLATEST_IMAGE};
+      - name: Build and push docker image with docker buildx action
+        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: doclinttest
+          push: true
+          tags: ${{ env.PUSH_TAGS }}
+          file: "Dockerfile"
+          cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}
+          cache-to: type=registry,ref=${{ vars.DOCKER_REGISTRY }}/${{ env.BUILDCACHE_IMAGE }},mode=max

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -8,6 +8,10 @@ on:
         required: true
       docker_token:
         required: true
+    outputs:
+      DOCKER_IMAGE_NAME:
+        description: "Name of docker image to be used"
+        value: ${{ jobs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
 
 # Assuming the below is in the workflow for an individual repository.
 # on:

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -152,6 +152,8 @@ jobs:
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3 / v3.8.0
 
       - name: Login to the Registry
+        # References the below commit, which matched both v3 and v3.3.0 at the time
+        # of this writing.
         # https://github.com/docker/login-action/commit/9780b0c442fbb1117ed29e0efdff1e18412f7567
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3 / v3.3.0
         with:

--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -146,10 +146,12 @@ jobs:
 
       - name: Setup BuildX
         if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
-        uses: docker/setup-buildx-action@v3
+        # https://github.com/docker/setup-buildx-action/commit/6524bf65af31da8d45b59e8c27de4bd072b392f5
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3 / v3.8.0
 
       - name: Login to the Registry
-        uses: docker/login-action@v3
+        # https://github.com/docker/login-action/commit/9780b0c442fbb1117ed29e0efdff1e18412f7567
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3 / v3.3.0
         with:
           registry: ${{ vars.DOCKER_REGISTRY }}
           username: ${{ vars.DOCKER_REGISTRY_USER }}
@@ -214,7 +216,8 @@ jobs:
           docker push ${STABLEORLATEST_IMAGE};
       - name: Build and push docker image with docker buildx action
         if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
-        uses: docker/build-push-action@v6
+        # https://github.com/docker/build-push-action/commit/67a2d409c0a876cbe6b11854e3e25193efe4e62d
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6 / v6.12.0
         with:
           context: .
           target: doclinttest

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -38,7 +38,7 @@ jobs:
   get-doclinttest-image:
     name: Get docker image
     # You do not appear to be able to use variables in this "uses" field.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@main
     secrets:
       token: ${{ secrets.token }}
       docker_token: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -25,9 +25,29 @@ defaults:
     shell: bash
 
 jobs:
+  # Build the base GeoIPS doclinttest image
+  # This image is used in all subsequent tests
+  # It is only built for the main GeoIPS package but is used by all repositories
+  #
+  # Within this image, the GeoIPS package is located in /packages/geoips and is
+  # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
+  # from /packages/geoips.
+  get-doclinttest-image:
+    name: Get docker image
+    needs: [get-job-flags]
+    # You do not appear to be able to use variables in this "uses" field.
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
+    secrets:
+      token: ${{ secrets.token }}
+      docker_token: ${{ secrets.docker_token }}
+    permissions:
+      packages: write
+      contents: write
+
   # Set variables that should be accessible to all jobs
   get-job-flags:
     runs-on: ${{ vars.RUNNER }}
+    needs: [get-doclinttest-image]
     env:
       CURR_REPO: ${{ github.event.repository.name }}
     outputs:
@@ -37,6 +57,7 @@ jobs:
       CI_BUILD_SPHINX_PDF: ${{ steps.get_job_flags.outputs.CI_BUILD_SPHINX_PDF }}
       CI_TEST_INTERFACES: ${{ steps.get_job_flags.outputs.CI_TEST_INTERFACES }}
       CI_TEST_PYTEST_SHORT: ${{ steps.get_job_flags.outputs.CI_TEST_PYTEST_SHORT }}
+      DOCKER_IMAGE_NAME: ${{ needs.get-doclinttest-image.outputs.DOCKER_IMAGE_NAME }}
     steps:
       - name: Get job flags
         id: get_job_flags
@@ -65,6 +86,9 @@ jobs:
                   echo "${flag}=true" >> $GITHUB_OUTPUT
               fi
           done
+          echo "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}"
+          echo "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}" >> ${GITHUB_OUTPUT}
 
   print-doc-test-variables:
     name: Print doc-test variables
@@ -79,25 +103,6 @@ jobs:
       CI_TEST_INTERFACES: ${{ needs.get-job-flags.outputs.CI_TEST_INTERFACES }}
       CI_TEST_PYTEST_SHORT: ${{ needs.get-job-flags.outputs.CI_TEST_PYTEST_SHORT }}
 
-  # Build the base GeoIPS doclinttest image
-  # This image is used in all subsequent tests
-  # It is only built for the main GeoIPS package but is used by all repositories
-  #
-  # Within this image, the GeoIPS package is located in /packages/geoips and is
-  # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
-  # from /packages/geoips.
-  get_doclinttest_image:
-    name: Get docker image
-    needs: [get-job-flags]
-    # You do not appear to be able to use variables in this "uses" field.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
-    secrets:
-      token: ${{ secrets.token }}
-      docker_token: ${{ secrets.docker_token }}
-    permissions:
-      packages: write
-      contents: write
-
   #################################################
   # Documentation builds - requires pip installed geoips, so use container
   #################################################
@@ -106,12 +111,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_BUILD_SPHINX_HTML == 'true' &&
-      (needs.get_doclinttest_image.result == 'success' ||
-      needs.get_doclinttest_image.result == 'skipped')
+      (needs.get-doclinttest-image.result == 'success' ||
+      needs.get-doclinttest-image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [get_doclinttest_image, get-job-flags]
+    needs: [get-doclinttest-image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
+      image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -133,7 +138,7 @@ jobs:
           # If we are specifically "template_basic_plugin" repo, then we must use
           # my_package as the package name.  Otherwise the package name matches
           # the plugin name.
-          echo "${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}"
+          echo "${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}"
           run_on_package=$CURR_REPO
           if [[ "$CURR_REPO" == "template_basic_plugin" ]]; then
             run_on_package=my_package
@@ -172,12 +177,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_TEST_INTERFACES == 'true' &&
-      (needs.get_doclinttest_image.result == 'success' ||
-      needs.get_doclinttest_image.result == 'skipped')
+      (needs.get-doclinttest-image.result == 'success' ||
+      needs.get-doclinttest-image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [get_doclinttest_image, get-job-flags]
+    needs: [get-doclinttest-image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
+      image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -208,12 +213,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_TEST_PYTEST_SHORT == 'true' &&
-      (needs.get_doclinttest_image.result == 'success' ||
-      needs.get_doclinttest_image.result == 'skipped')
+      (needs.get-doclinttest-image.result == 'success' ||
+      needs.get-doclinttest-image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [get_doclinttest_image, get-job-flags]
+    needs: [get-doclinttest-image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
+      image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -86,8 +86,8 @@ jobs:
   # Within this image, the GeoIPS package is located in /packages/geoips and is
   # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
   # from /packages/geoips.
-  build_doclinttest_image:
-    name: Build docker image
+  get_doclinttest_image:
+    name: Get docker image
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
     secrets:
@@ -105,12 +105,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_BUILD_SPHINX_HTML == 'true' &&
-      (needs.build_doclinttest_image.result == 'success' ||
-      needs.build_doclinttest_image.result == 'skipped')
+      (needs.get_doclinttest_image.result == 'success' ||
+      needs.get_doclinttest_image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [build_doclinttest_image, get-job-flags]
+    needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -170,12 +170,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_TEST_INTERFACES == 'true' &&
-      (needs.build_doclinttest_image.result == 'success' ||
-      needs.build_doclinttest_image.result == 'skipped')
+      (needs.get_doclinttest_image.result == 'success' ||
+      needs.get_doclinttest_image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [build_doclinttest_image, get-job-flags]
+    needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -206,12 +206,12 @@ jobs:
       ! cancelled() &&
       vars.USE_CONDA_FOR_ACTIONS != 'true' &&
       needs.get-job-flags.outputs.CI_TEST_PYTEST_SHORT == 'true' &&
-      (needs.build_doclinttest_image.result == 'success' ||
-      needs.build_doclinttest_image.result == 'skipped')
+      (needs.get_doclinttest_image.result == 'success' ||
+      needs.get_doclinttest_image.result == 'skipped')
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
-    needs: [build_doclinttest_image, get-job-flags]
+    needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -133,7 +133,7 @@ jobs:
           # If we are specifically "template_basic_plugin" repo, then we must use
           # my_package as the package name.  Otherwise the package name matches
           # the plugin name.
-          echo "${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}"
+          echo "${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}"
           run_on_package=$CURR_REPO
           if [[ "$CURR_REPO" == "template_basic_plugin" ]]; then
             run_on_package=my_package
@@ -177,7 +177,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -213,7 +213,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCKER_IMAGE_NAME }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -133,6 +133,7 @@ jobs:
           # If we are specifically "template_basic_plugin" repo, then we must use
           # my_package as the package name.  Otherwise the package name matches
           # the plugin name.
+          echo "${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}"
           run_on_package=$CURR_REPO
           if [[ "$CURR_REPO" == "template_basic_plugin" ]]; then
             run_on_package=my_package
@@ -176,7 +177,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -212,7 +213,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [get_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.get_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -32,6 +32,9 @@ jobs:
   # Within this image, the GeoIPS package is located in /packages/geoips and is
   # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
   # from /packages/geoips.
+  #
+  # Note the DOCKER_IMAGE_NAME is returned from reusable-build-docker-image
+  # by including it in the "outputs" listed at the top of the workflow.
   get-doclinttest-image:
     name: Get docker image
     # You do not appear to be able to use variables in this "uses" field.
@@ -56,6 +59,8 @@ jobs:
       CI_BUILD_SPHINX_PDF: ${{ steps.get_job_flags.outputs.CI_BUILD_SPHINX_PDF }}
       CI_TEST_INTERFACES: ${{ steps.get_job_flags.outputs.CI_TEST_INTERFACES }}
       CI_TEST_PYTEST_SHORT: ${{ steps.get_job_flags.outputs.CI_TEST_PYTEST_SHORT }}
+      # DOCKER_IMAGE_NAME is defined in the "outputs" section at the top of
+      # reusable-build-docker-image
       DOCKER_IMAGE_NAME: ${{ needs.get-doclinttest-image.outputs.DOCKER_IMAGE_NAME }}
     steps:
       - name: Get job flags

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -17,30 +17,8 @@ on:
 #   workflow_dispatch:
 
 env:
-  # REQUIRED organization level variables used in this workflow.
-  #   ${{ github.event.repository.default_branch }} is used throughout
-  #     rather than main to generalize default branch
-  #     (removed DEFAULT_BRANCH org var)
-  #   DOCKER_REGISTRY: URL to the docker registry
-  #   DOCKER_REGISTRY_USER: user to sign into DOCKER_REGISTRY
-  #   DOCKER_REGISTRY_TOKEN: token for USER user to sign into DOCKER_REGISTRY
-  #   RUNNER: default runner
-  #   UPLOAD_GITHUB_ARTIFACTS: true/false, specify whether to upload artifacts to github
-  #   USE_DOCKER_BUILDX_ACTION: true/false, specify whether to use the docker buildx action
-
-  # OPTIONAL organization level variables:
-  #   # Some system implementations may require different runners for building and
-  #   # running docker containers - allow specifying separately. Defaults to vars.RUNNER
-  #   # if these are not defined. Note env context nor strings are supported in the
-  #   # runs-on field, so we MUST use the vars context for the default.
-  #   RUNNER_DOCKERBUILD: runner to build docker containers
-  #   RUNNER_DOCKERRUN: runner to run docker containers
-
   # The path to the GeoIPS package in DOCLINTTEST images
   BASE_GEOIPS_PATH: /packages/geoips
-  # Allow overriding the doclinttest image tag used for plugin packages
-  # Allows using a different version of the doc, lint, and test code
-  PLUGIN_DOCLINTTEST_TAG: doclinttest-stable
 
 defaults:
   run:
@@ -53,13 +31,6 @@ jobs:
     env:
       CURR_REPO: ${{ github.event.repository.name }}
     outputs:
-      # The name of the untagged docker images to be created by this workflow
-      IMAGE_NAME: ${{ steps.set_image_name.outputs.IMAGE_NAME }}
-      REPO_NAME: ${{ steps.set_image_name.outputs.REPO_NAME }}
-      # The tag to use for the doclinttest images
-      DOCLINTTEST_TAG: ${{ steps.set_doclinttest_tag.outputs.DOCLINTTEST_TAG }}
-      # The image to use for doclinttest jobs
-      DOCLINTTEST_IMAGE: ${{ steps.set_doclinttest_image.outputs.DOCLINTTEST_IMAGE }}
       # Flags for enabling/disabling various parts of the workflow
       # Default to enabled unless overridden by a repository-level variable
       CI_BUILD_SPHINX_HTML: ${{ steps.get_job_flags.outputs.CI_BUILD_SPHINX_HTML }}
@@ -67,42 +38,6 @@ jobs:
       CI_TEST_INTERFACES: ${{ steps.get_job_flags.outputs.CI_TEST_INTERFACES }}
       CI_TEST_PYTEST_SHORT: ${{ steps.get_job_flags.outputs.CI_TEST_PYTEST_SHORT }}
     steps:
-      - name: Set the image name
-        id: set_image_name
-        run: |
-          repo_name=$(echo ${{ github.repository }} | cut -d'/' -f2)
-          # Create an image name using the organiztion and repository names, lowercase
-          image_name=${{ vars.DOCKER_REGISTRY_USER }}/geoips
-          echo "REPO_NAME=${repo_name}"
-          echo "REPO_NAME=${repo_name}" >> ${GITHUB_ENV}
-          echo "REPO_NAME=${repo_name}" >> ${GITHUB_OUTPUT}
-          echo "IMAGE_NAME=${image_name}"
-          echo "IMAGE_NAME=${image_name}" >> ${GITHUB_ENV}
-          echo "IMAGE_NAME=${image_name}" >> ${GITHUB_OUTPUT}
-      - name: Set doclinttest image tag
-        id: set_doclinttest_tag
-        run: |
-          echo "CURR_REPO: ${CURR_REPO}"
-          # If the current repository is geoips, use the image we're about to build
-          # for running tests and building docs.
-          if [[ "${CURR_REPO}" == "geoips" ]]; then
-              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}"
-              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}" >> ${GITHUB_ENV}
-              echo "DOCLINTTEST_TAG=doclinttest-${GITHUB_SHA}" >> ${GITHUB_OUTPUT}
-          else
-              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}"
-              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}" >> ${GITHUB_ENV}
-              echo "DOCLINTTEST_TAG=${PLUGIN_DOCLINTTEST_TAG}" >> ${GITHUB_OUTPUT}
-          fi
-      - name: Set doclinttest image
-        id: set_doclinttest_image
-        run: |
-          owner=${{ github.repository_owner }}
-          owner=${owner,,}
-          doclinttest_image_name=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}
-          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}"
-          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_ENV}
-          echo "DOCLINTTEST_IMAGE=${{ env.IMAGE_NAME }}:${DOCLINTTEST_TAG}" >> ${GITHUB_OUTPUT}
       - name: Get job flags
         id: get_job_flags
         run: |
@@ -139,10 +74,6 @@ jobs:
     with:
       # These are outputs defined above.  Explicitly pass them in here to track
       # what variables we have available to this workflow.
-      IMAGE_NAME: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}
-      REPO_NAME: ${{ needs.get-job-flags.outputs.REPO_NAME }}
-      DOCLINTTEST_TAG: ${{ needs.get-job-flags.outputs.DOCLINTTEST_TAG }}
-      DOCLINTTEST_IMAGE: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       CI_BUILD_SPHINX_HTML: ${{ needs.get-job-flags.outputs.CI_BUILD_SPHINX_HTML }}
       CI_BUILD_SPHINX_PDF: ${{ needs.get-job-flags.outputs.CI_BUILD_SPHINX_PDF }}
       CI_TEST_INTERFACES: ${{ needs.get-job-flags.outputs.CI_TEST_INTERFACES }}
@@ -156,98 +87,9 @@ jobs:
   # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
   # from /packages/geoips.
   build_doclinttest_image:
-    runs-on: ${{ vars.RUNNER_DOCKERBUILD || vars.RUNNER }}
-    needs: get-job-flags
-    if: >
-      ! cancelled() &&
-      vars.USE_CONDA_FOR_ACTIONS != 'true' &&
-      github.event.repository.name == 'geoips'
-    env:
-      IMAGE_NAME: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}
-      BUILDCACHE_IMAGE: ${{ needs.get-job-flags.outputs.IMAGE_NAME }}:buildcache
-      DOCLINTTEST_IMAGE: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
-    # Can't write to registry without this
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup BuildX
-        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to the Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ vars.DOCKER_REGISTRY }}
-          username: ${{ vars.DOCKER_REGISTRY_USER }}
-          password: ${{ secrets.docker_token }}
-
-      # This cache allows the second push below when on the default branch
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Create tags
-        run: |
-          tags="${DOCLINTTEST_IMAGE},${BUILDCACHE_IMAGE}"
-          echo "GITHUB REF: ${GITHUB_REF}"
-          echo "Default Branch: refs/heads/${{ github.event.repository.default_branch }}"
-          echo "runner os: ${{ runner.os }}"
-          echo "github sha: ${{ github.sha }}"
-          echo "build cache image: ${{ env.BUILDCACHE_IMAGE }}"
-          if [[ "${GITHUB_REF}" == "refs/heads/${{ github.event.repository.default_branch }}" ]]; then
-            stableorlatest_image="${IMAGE_NAME}:doclinttest-stable"
-            tags="${tags},${stableorlatest_image}"
-          else
-            stableorlatest_image="${IMAGE_NAME}:doclinttest-latest"
-            tags="${tags},${stableorlatest_image}"
-          fi
-          # PUSH_TAGS is used with the docker buildx action
-          echo "PUSH_TAGS=${tags}"
-          echo "PUSH_TAGS=${tags}" >> $GITHUB_ENV
-          # STABLEORLATEST_IMAGE is only used with the explicit docker build command.
-          # It is the full path to the stable or latest image tag.
-          # The explicit docker build command requires pushing each image separately
-          # to the registry - so we need to track the stable/latest tag in addition
-          # to the DOCLINTTEST_IMAGE and BUILDCACHE_IMAGE tags
-          echo "STABLEORLATEST_IMAGE=${stableorlatest_image}"
-          echo "STABLEORLATEST_IMAGE=${stableorlatest_image}" >> $GITHUB_ENV
-
-      # If using docker buildx was requested via organization variable,
-      # DO NOT run this section.
-      - name: Build and push docker image with explicit docker build
-        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'false' }}
-        # > makes newlines into spaces, so single command on multiple lines.
-        run: >
-          which docker;
-          docker build
-          --file Dockerfile
-          --tag ${DOCLINTTEST_IMAGE}
-          --tag ${BUILDCACHE_IMAGE}
-          --tag ${STABLEORLATEST_IMAGE}
-          --target doclinttest
-          .;
-          docker push ${BUILDCACHE_IMAGE};
-          docker push ${DOCLINTTEST_IMAGE};
-          docker push ${STABLEORLATEST_IMAGE};
-      - name: Build and push docker image with docker buildx action
-        if: ${{ vars.USE_DOCKER_BUILDX_ACTION == 'true' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: doclinttest
-          push: true
-          tags: ${{ env.PUSH_TAGS }}
-          file: "Dockerfile"
-          cache-from: type=registry,ref=${{ env.BUILDCACHE_IMAGE }}
-          cache-to: type=registry,ref=${{ vars.DOCKER_REGISTRY }}/${{ env.BUILDCACHE_IMAGE }},mode=max
+    name: Build docker image
+    # You do not appear to be able to use variables in this "uses" field.
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
 
   #################################################
   # Documentation builds - requires pip installed geoips, so use container
@@ -262,7 +104,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [build_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -327,7 +169,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [build_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}
@@ -363,7 +205,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_DOCKERRUN || vars.RUNNER }}
     needs: [build_doclinttest_image, get-job-flags]
     container:
-      image: ${{ needs.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
+      image: ${{ needs.build_doclinttest_image.get-job-flags.outputs.DOCLINTTEST_IMAGE }}
       credentials:
         username: ${{ vars.DOCKER_REGISTRY_USER }}
         password: ${{ secrets.docker_token }}

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -90,6 +90,12 @@ jobs:
     name: Build docker image
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
+    secrets:
+      token: ${{ secrets.token }}
+      docker_token: ${{ secrets.docker_token }}
+    permissions:
+      packages: write
+      contents: write
 
   #################################################
   # Documentation builds - requires pip installed geoips, so use container

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -34,7 +34,6 @@ jobs:
   # from /packages/geoips.
   get-doclinttest-image:
     name: Get docker image
-    needs: [get-job-flags]
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
     secrets:

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -88,6 +88,7 @@ jobs:
   # from /packages/geoips.
   get_doclinttest_image:
     name: Get docker image
+    needs: [get-job-flags]
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-build-docker-image.yaml@build_stable_image_on_tag
     secrets:

--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -66,8 +66,8 @@ jobs:
               fi
           done
 
-  print-variables:
-    name: Print variables
+  print-doc-test-variables:
+    name: Print doc-test variables
     needs: [get-job-flags]
     # You do not appear to be able to use variables in this "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-print-variables.yaml@main

--- a/.github/workflows/ruleset-doc-test.yaml
+++ b/.github/workflows/ruleset-doc-test.yaml
@@ -32,7 +32,7 @@ jobs:
   lint:
     name: Doctest
     # You do not appear to be able to use variables in the "uses" field.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-doc-test.yaml@main
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-doc-test.yaml@build_stable_image_on_tag
     if: "!contains(github.event.repository.name, 'test_data_')"
     permissions:
       contents: write

--- a/.github/workflows/ruleset-doc-test.yaml
+++ b/.github/workflows/ruleset-doc-test.yaml
@@ -32,7 +32,7 @@ jobs:
   lint:
     name: Doctest
     # You do not appear to be able to use variables in the "uses" field.
-    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-doc-test.yaml@build_stable_image_on_tag
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-doc-test.yaml@main
     if: "!contains(github.event.repository.name, 'test_data_')"
     permissions:
       contents: write

--- a/docs/source/releases/latest/add-codeowners-file.yaml
+++ b/docs/source/releases/latest/add-codeowners-file.yaml
@@ -1,0 +1,17 @@
+continuous integration:
+  - title: "Add CODEOWNERS file."
+    description: |
+      Enforces review from codeowners
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - .github/CODEOWNERS
+    related-issue:
+      number: null
+      repo_url: ""
+    date:
+      start: "Jan 09 2025"
+      finish: "Jan 09 2025"

--- a/docs/source/releases/latest/build_stable_image_on_tag.yaml
+++ b/docs/source/releases/latest/build_stable_image_on_tag.yaml
@@ -1,0 +1,43 @@
+continuous integration:
+  - title: "Build stable image on tag."
+    description: |
+      Ensure stable geoips docker image is built on tag/release.  This ensures
+      the latest stable image is available for plugin packages to use in PR
+      status checks.
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - .github/workflows/reusable-build-docker-image.yaml
+      modified:
+        - .github/workflows/reusable-doc-test.yaml
+    related-issue:
+      number: null
+      repo_url: ""
+    date:
+      start: "Jan 09 2025"
+      finish: "Jan 09 2025"
+  - title: "Add release note template for open source upload release note."
+    description: |
+      Template release note to copy for open source upload during release process.
+      Must ensure all repos have a release note for the CURRENT geoips version,
+      not just for the latest tagged version for the current repository.
+      This release note tracks that a repo was uploaded with the given geoips
+      version.
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - docs/templates/release_note_version_release/open-source-upload.yaml
+      modified:
+        - ""
+    related-issue:
+      number: null
+      repo_url: ""
+    date:
+      start: "Jan 09 2025"
+      finish: "Jan 09 2025"

--- a/docs/templates/release_note_version_release/open-source-upload.yaml
+++ b/docs/templates/release_note_version_release/open-source-upload.yaml
@@ -1,0 +1,7 @@
+Release Updates - Open Source Upload:
+- title: Open source upload
+  description: "This repo updated with current geoips version release"
+  files:
+    modified:
+    - standard sync files
+    - release notes

--- a/sync/.github/CODEOWNERS
+++ b/sync/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# More info:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @cira-review and @nrl-review will be requested for
+# review when someone opens a pull request.
+*       @NRLMMD-GEOIPS/nrl-review


### PR DESCRIPTION
Move the docker build portion of doc-test.yaml into a separate reusable workflow.  Call this reusable workflow from either the geopis repo build-stable-image.yaml workflow (called on tag/release, to ensure the stable image is avialble for plugin repositories), or from the reusable-doc-test.yaml workflow (where it should only build the local image, not the stable image)

Will test from the geoips repo build_stable_image_on_tag branch/PR