### PR TITLE
Install geoips in editable mode (hotfix for failing integration tests)

### DIFF
--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -337,7 +337,7 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory $PWD
       - name: Pip install package
-        run: pip install -v .
+        run: pip install -v -e .
       - name: create_plugin_registries
         run: create_plugin_registries
       - name: Run code check script interfaces
@@ -375,7 +375,7 @@ jobs:
       - name: Configure Git safe directory
         run: git config --global --add safe.directory $PWD
       - name: Pip install package
-        run: pip install -v .
+        run: pip install -v -e .
       - name: create_plugin_registries
         run: create_plugin_registries
       # Run unit tests for this repo if they exist

--- a/docs/source/releases/latest/hotfix-unit-tests.yaml
+++ b/docs/source/releases/latest/hotfix-unit-tests.yaml
@@ -1,0 +1,11 @@
+bug fix:
+- title: 'Install geoips in editable mode (hotfix for failing integration tests)'
+  description: 'Fixes failing unit tests that should be passing by reverting to previous behaviour and installing GeoIPS in editable mode.'
+  files:
+    - '.github/workflows/reusable-doc-test.yaml'
+  related-issue:
+    number: 875
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips/'
+  date:
+    start: Jan 22 2025
+    finish: Jan 23 2025

--- a/docs/source/releases/latest/hotfix-unit-tests.yaml
+++ b/docs/source/releases/latest/hotfix-unit-tests.yaml
@@ -2,7 +2,7 @@ bug fix:
 - title: 'Install geoips in editable mode (hotfix for failing integration tests)'
   description: 'Fixes failing unit tests that should be passing by reverting to previous behaviour and installing GeoIPS in editable mode.'
   files:
-  modified:
+    modified:
     - '.github/workflows/reusable-doc-test.yaml'
   related-issue:
     number: 875

--- a/docs/source/releases/latest/hotfix-unit-tests.yaml
+++ b/docs/source/releases/latest/hotfix-unit-tests.yaml
@@ -2,6 +2,7 @@ bug fix:
 - title: 'Install geoips in editable mode (hotfix for failing integration tests)'
   description: 'Fixes failing unit tests that should be passing by reverting to previous behaviour and installing GeoIPS in editable mode.'
   files:
+  modified:
     - '.github/workflows/reusable-doc-test.yaml'
   related-issue:
     number: 875


### PR DESCRIPTION
Fixes failing unit tests that should be passing by installing GeoIPS in editable mode. For example, the unit tests should pass on this PR (https://github.com/NRLMMD-GEOIPS/geoips/pull/784) and *do* if it's installed in editable mode. 

In the long term, tests should pass when run with geoips installed in editable mode AND non-editable mode. However, this hot fix should be merged in the short term to prevent it from blocking other PRs. 

https://github.com/NRLMMD-GEOIPS/geoips/pull/876 on GeoIPS is the first step at getting unit tests to pass in non-editable mode. However, other tests need to be re-written to pass in non-editable mode and require non-trivial updates. This fixes https://github.com/NRLMMD-GEOIPS/geoips/issues/875