### PR TITLE
29 convert prs to draft after every commit on an open pr

### DIFF
--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -34,38 +34,21 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
+          echo "Getting metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
           
-          gh --version
-          
-          echo "Listing all open PRs:"
-          gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
-          
-          echo "Checking PR via API:"
-          curl -s -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
-          
-          echo "Attempting to fetch PR with gh CLI (with debugging)..."
-          set +e  # Don't exit on error
-          gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
-          PR_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
-          
-          echo "gh pr view exit code: ${PR_EXIT_CODE}"
-          
-          if [[ $PR_EXIT_CODE -ne 0 ]]; then
-            echo "::error::Failed to fetch PR #${PR_NUMBER}"
+          # Check if PR exists and get its current status
+          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,isDraft,author,url 2>&1)
+          if [[ $? -ne 0 ]]; then
+            echo "::error::Failed to fetch PR #${PR_NUMBER}: ${PR_DATA}"
             echo "pr_exists=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-          
-          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
           
           # Print the PR data for debugging
           echo "PR Data: ${PR_DATA}"
           
           # Extract PR data from json response
-          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
+          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.isDraft')
           PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
           PR_URL=$(echo "$PR_DATA" | jq -r '.url')
           

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -98,13 +98,14 @@ jobs:
           steps.check_pr.outputs.should_convert == 'true'
         id: convert_to_draft
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}  # Use your PAT instead of github.token
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
           # The correct command to convert a PR to draft
+          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -104,37 +104,42 @@ jobs:
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # Debug: Show available gh commands
-          echo "Available gh pr commands:"
-          gh pr --help
+          # Try the gh pr ready command with --undo flag to convert to draft
+          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
+          EXIT_CODE=$?
           
-          # Debug: Show gh pr edit options
-          echo "gh pr edit options:"
-          gh pr edit --help
-          
-          # Try using the GraphQL API directly as a workaround
-          echo "Attempting to convert PR to draft using GraphQL API..."
-          PR_ID=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json id --jq '.id')
-          
-          if [[ -n "$PR_ID" ]]; then
-            # Use the GraphQL API to convert the PR to draft
-            QUERY='mutation ConvertToDraft($prId: ID!) { convertPullRequestToDraft(input: {pullRequestId: $prId}) { pullRequest { isDraft } } }'
+          if [[ $EXIT_CODE -eq 0 ]]; then
+            echo "Successfully converted PR to draft status"
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
+            # Let's try a different approach with a REST API call
+            echo "Attempting to convert PR to draft using REST API..."
             
-            RESULT=$(gh api graphql -f query="$QUERY" -f prId="$PR_ID" 2>&1)
-            EXIT_CODE=$?
+            # Get the PR node ID
+            PR_NODE_ID=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json id --jq '.id')
             
-            echo "GraphQL API Result: $RESULT"
-            
-            if [[ $EXIT_CODE -eq 0 ]]; then
-              echo "Successfully converted PR to draft status via GraphQL API"
-              echo "success=true" >> $GITHUB_OUTPUT
+            if [[ -n "$PR_NODE_ID" ]]; then
+              # Use the REST API to convert the PR to draft
+              REST_RESULT=$(curl -s -X POST \
+                -H "Authorization: token $GH_TOKEN" \
+                -H "Accept: application/vnd.github.v3+json" \
+                "https://api.github.com/graphql" \
+                -d "{\"query\":\"mutation { convertPullRequestToDraft(input: {pullRequestId: \\\"$PR_NODE_ID\\\"}) { pullRequest { id } } }\"}" 2>&1)
+              
+              REST_EXIT_CODE=$?
+              
+              if [[ $REST_EXIT_CODE -eq 0 && ! "$REST_RESULT" =~ "errors" ]]; then
+                echo "Successfully converted PR to draft status via REST API"
+                echo "success=true" >> $GITHUB_OUTPUT
+              else
+                echo "::error::Failed to convert PR to draft status via REST API: ${REST_RESULT}"
+                echo "success=false" >> $GITHUB_OUTPUT
+              fi
             else
-              echo "::error::Failed to convert PR to draft status via GraphQL API: ${RESULT}"
+              echo "::error::Could not get PR ID for REST API conversion"
               echo "success=false" >> $GITHUB_OUTPUT
             fi
-          else
-            echo "::error::Could not get PR ID for GraphQL conversion"
-            echo "success=false" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -26,55 +26,55 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
-      
-        - name: Get PR information
-          id: pr_info
-          env:
-            GH_TOKEN: ${{ github.token }}
-            PR_NUMBER: ${{ inputs.pr_number }}
-            GITHUB_REPOSITORY: ${{ github.repository }}
-          run: |
-            echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
-            
-            gh --version
-            
-            echo "Listing all open PRs:"
-            gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
-            
-            echo "Checking PR via API:"
-            curl -s -H "Authorization: token ${GH_TOKEN}" \
-              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
-            
-            echo "Attempting to fetch PR with gh CLI (with debugging)..."
-            set +e  # Don't exit on error
-            gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
-            PR_EXIT_CODE=$?
-            set -e  # Re-enable exit on error
-            
-            echo "gh pr view exit code: ${PR_EXIT_CODE}"
-            
-            if [[ $PR_EXIT_CODE -ne 0 ]]; then
-              echo "::error::Failed to fetch PR #${PR_NUMBER}"
-              echo "pr_exists=false" >> $GITHUB_OUTPUT
-              exit 1
-            fi
-            
-            PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
-            
-            # Print the PR data for debugging
-            echo "PR Data: ${PR_DATA}"
-            
-            # Extract PR data from json response
-            IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
-            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
-            PR_URL=$(echo "$PR_DATA" | jq -r '.url')
-            
-            echo "PR #${PR_NUMBER} found. Is draft: ${IS_DRAFT}"
-            echo "pr_exists=true" >> $GITHUB_OUTPUT
-            echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
-            echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
-            echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-          shell: bash
+    steps:
+      - name: Get PR information
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
+          
+          gh --version
+          
+          echo "Listing all open PRs:"
+          gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
+          
+          echo "Checking PR via API:"
+          curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
+          
+          echo "Attempting to fetch PR with gh CLI (with debugging)..."
+          set +e  # Don't exit on error
+          gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
+          PR_EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+          
+          echo "gh pr view exit code: ${PR_EXIT_CODE}"
+          
+          if [[ $PR_EXIT_CODE -ne 0 ]]; then
+            echo "::error::Failed to fetch PR #${PR_NUMBER}"
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
+          
+          # Print the PR data for debugging
+          echo "PR Data: ${PR_DATA}"
+          
+          # Extract PR data from json response
+          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+          PR_URL=$(echo "$PR_DATA" | jq -r '.url')
+          
+          echo "PR #${PR_NUMBER} found. Is draft: ${IS_DRAFT}"
+          echo "pr_exists=true" >> $GITHUB_OUTPUT
+          echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
+          echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
+        shell: bash
         
       - name: Check if PR should be converted to draft
         id: check_pr

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -106,17 +106,17 @@ jobs:
           
           # The correct command to convert a PR to draft
           echo "gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo"
-          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
-          EXIT_CODE=$?
+          #OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
+          #EXIT_CODE=$?
           
-          if [[ $EXIT_CODE -eq 0 ]]; then
-            echo "Successfully converted PR to draft status"
-            #echo "success=true" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
-            #echo "success=false" >> $GITHUB_OUTPUT
-            # Continue workflow instead of failing to allow comment step
-          fi
+          #if [[ $EXIT_CODE -eq 0 ]]; then
+          #  echo "Successfully converted PR to draft status"
+          #  #echo "success=true" >> $GITHUB_OUTPUT
+          #else
+          #  echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
+          #  #echo "success=false" >> $GITHUB_OUTPUT
+          #  # Continue workflow instead of failing to allow comment step
+          #fi
           echo THIS IS CURRENTLY BROKEN, NEEDS DIFFERENT PERMISSIONS TO WORK
           echo "success=true" >> $GITHUB_OUTPUT
         shell: bash

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -1,7 +1,7 @@
 name: Change PR to Draft
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       pr_number:
         description: 'PR Number to convert to draft'
@@ -17,7 +17,7 @@ on:
         required: false
         type: boolean
         default: true
-
+        
 jobs:
   change-to-draft:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Get PR information
         id: pr_info
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}  # Changed from secrets.GITHUB_TOKEN
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           echo "Fetching metadata for PR #${PR_NUMBER}..."
@@ -43,6 +43,9 @@ jobs:
             echo "pr_exists=false" >> $GITHUB_OUTPUT
             exit 1
           fi
+          
+          # Print the PR data for debugging
+          echo "PR Data: ${PR_DATA}"
           
           # Extract PR data from json response
           IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -91,19 +91,6 @@ jobs:
           fi
         shell: bash
 
-      - name: Generate GitHub App Token
-        if: >- # Condition when conversion might be needed
-          steps.pr_info.outputs.pr_exists == 'true' && 
-          steps.pr_info.outputs.is_draft == 'false' && 
-          steps.check_pr.outputs.should_convert == 'true'
-        id: generate_token
-        uses: tibdex/github-app-token@v2 # Use the action
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          # Optional: specify repository if different from current one
-          # repository: ${{ github.repository }} 
-
       - name: Change PR to Draft
         if: >-
           steps.pr_info.outputs.pr_exists == 'true' && 
@@ -111,14 +98,14 @@ jobs:
           steps.check_pr.outputs.should_convert == 'true'
         id: convert_to_draft
         env:
-          # Use the App token generated in the previous step
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }} 
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          echo "Converting PR #${PR_NUMBER} to draft status using GitHub App token..."
+          echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # Now gh pr ready --undo should work with the App token
+          # The correct command to convert a PR to draft
+          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           
@@ -126,11 +113,9 @@ jobs:
             echo "Successfully converted PR to draft status"
             echo "success=true" >> $GITHUB_OUTPUT
           else
-            # Output the actual error from the gh command
-            echo "::error::Failed to convert PR to draft status: ${OUTPUT}" 
+            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
             echo "success=false" >> $GITHUB_OUTPUT
-            # Consider failing the step if conversion is critical
-            # exit 1 
+            # Continue workflow instead of failing to allow comment step
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -25,6 +25,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      statuses: write
       
     steps:
       - name: Get PR information

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -91,37 +91,46 @@ jobs:
           fi
         shell: bash
 
-      - name: Change PR to Draft # and do that via the API because the default token can't with the gh CLI
+      - name: Generate GitHub App Token
+        if: >- # Condition when conversion might be needed
+          steps.pr_info.outputs.pr_exists == 'true' && 
+          steps.pr_info.outputs.is_draft == 'false' && 
+          steps.check_pr.outputs.should_convert == 'true'
+        id: generate_token
+        uses: tibdex/github-app-token@v2 # Use the action
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Optional: specify repository if different from current one
+          # repository: ${{ github.repository }} 
+
+      - name: Change PR to Draft
         if: >-
           steps.pr_info.outputs.pr_exists == 'true' && 
           steps.pr_info.outputs.is_draft == 'false' && 
           steps.check_pr.outputs.should_convert == 'true'
         id: convert_to_draft
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use the App token generated in the previous step
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }} 
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          echo "Converting PR #${PR_NUMBER} to draft status..."
+          echo "Converting PR #${PR_NUMBER} to draft status using GitHub App token..."
           
-          # Use REST API instead of gh pr ready --undo
-          RESPONSE=$(curl -s -X PATCH \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
-            -d '{"draft":true}')
-
-          echo "$RESPONSE"
+          # Now gh pr ready --undo should work with the App token
+          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
+          EXIT_CODE=$?
           
-          # Check if the update was successful
-          UPDATED_DRAFT=$(echo "$RESPONSE" | jq -r '.draft')
-          
-          if [[ "$UPDATED_DRAFT" == "true" ]]; then
+          if [[ $EXIT_CODE -eq 0 ]]; then
             echo "Successfully converted PR to draft status"
             echo "success=true" >> $GITHUB_OUTPUT
           else
-            echo "::error::Failed to convert PR to draft status: $(echo "$RESPONSE" | jq -r '.message')"
+            # Output the actual error from the gh command
+            echo "::error::Failed to convert PR to draft status: ${OUTPUT}" 
             echo "success=false" >> $GITHUB_OUTPUT
+            # Consider failing the step if conversion is critical
+            # exit 1 
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -66,6 +66,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           SKIP_LABEL_CHECK: ${{ inputs.skip_label_check }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Skip label check if requested
           if [[ "$SKIP_LABEL_CHECK" == "true" ]]; then
@@ -77,8 +78,8 @@ jobs:
           # Check for labels that would exclude this PR from being converted to draft
           echo "Checking PR #${PR_NUMBER} for exclusion labels..."
           
-          # Use jq to check for specific labels
-          EXEMPT_LABEL=$(gh pr view ${PR_NUMBER} --json labels \
+          # Use jq to check for specific labels - make sure to specify the repo
+          EXEMPT_LABEL=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json labels \
             --jq '.labels | map(select(.name == "no-auto-draft")) | length')
           
           if [[ "$EXEMPT_LABEL" -gt 0 ]]; then
@@ -99,11 +100,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
           # Attempt to convert PR to draft and capture output
-          OUTPUT=$(gh pr ready ${PR_NUMBER} --draft 2>&1)
+          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --draft 2>&1)
           EXIT_CODE=$?
           
           if [[ $EXIT_CODE -eq 0 ]]; then
@@ -125,6 +127,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_AUTHOR: ${{ steps.pr_info.outputs.pr_author }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Add a helpful comment explaining why the PR was changed to draft
           COMMENT="Hi @${PR_AUTHOR}, this PR has been automatically converted to draft status.
@@ -133,7 +136,7 @@ jobs:
           If you want to prevent this behavior for this PR please add a \`no-auto-draft\` label to this PR.
           *This is an automated action by a CI workflow.*"
           
-          gh pr comment ${PR_NUMBER} --body "$COMMENT"
+          gh pr comment ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --body "$COMMENT"
         shell: bash
 
       - name: Notify on conversion failure

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -31,14 +31,21 @@ jobs:
       - name: Get PR information
         id: pr_info
         env:
-          GH_TOKEN: ${{ github.token }}  # Changed from secrets.GITHUB_TOKEN
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          echo "Fetching metadata for PR #${PR_NUMBER}..."
+          echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
+          gh --version
           
-          # Check if PR exists and get its current status
-          PR_DATA=$(gh pr view ${PR_NUMBER} --json number,draft,author,url 2>&1)
-          if [[ $? -ne 0 ]]; then
+          echo "Attempting to fetch PR with explicit repository..."
+          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url 2>&1)
+          PR_EXIT_CODE=$?
+          
+          echo "Command output: ${PR_DATA}"
+          echo "Exit code: ${PR_EXIT_CODE}"
+          
+          if [[ $PR_EXIT_CODE -ne 0 ]]; then
             echo "::error::Failed to fetch PR #${PR_NUMBER}: ${PR_DATA}"
             echo "pr_exists=false" >> $GITHUB_OUTPUT
             exit 1

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
           # The correct command to convert a PR to draft
-          echo $(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo)
+          echo "gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo"
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -63,7 +63,7 @@ jobs:
         id: check_pr
         if: steps.pr_info.outputs.pr_exists == 'true' && steps.pr_info.outputs.is_draft == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           SKIP_LABEL_CHECK: ${{ inputs.skip_label_check }}
         run: |
@@ -97,7 +97,7 @@ jobs:
           steps.check_pr.outputs.should_convert == 'true'
         id: convert_to_draft
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
@@ -122,7 +122,7 @@ jobs:
           steps.pr_info.outputs.pr_exists == 'true' && 
           steps.convert_to_draft.outputs.success == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_AUTHOR: ${{ steps.pr_info.outputs.pr_author }}
         run: |
@@ -130,7 +130,7 @@ jobs:
           COMMENT="Hi @${PR_AUTHOR}, this PR has been automatically converted to draft status.
           When you're ready for review again, please mark it as 'Ready for review'.
           
-          If you want to prevent this behavior for this PR please add a `no-auto-draft` label to this PR.
+          If you want to prevent this behavior for this PR please add a \`no-auto-draft\` label to this PR.
           *This is an automated action by a CI workflow.*"
           
           gh pr comment ${PR_NUMBER} --body "$COMMENT"
@@ -142,7 +142,7 @@ jobs:
           steps.pr_info.outputs.pr_exists == 'true' && 
           steps.convert_to_draft.outputs.success == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           echo "⚠️ Draft Conversion Failed"

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -104,8 +104,8 @@ jobs:
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # Attempt to convert PR to draft and capture output
-          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --draft 2>&1)
+          # The correct command to convert a PR to draft
+          OUTPUT=$(gh pr edit ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --draft 2>&1)
           EXIT_CODE=$?
           
           if [[ $EXIT_CODE -eq 0 ]]; then

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -104,17 +104,37 @@ jobs:
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # The correct command to convert a PR to draft
-          OUTPUT=$(gh pr edit ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --draft 2>&1)
-          EXIT_CODE=$?
+          # Debug: Show available gh commands
+          echo "Available gh pr commands:"
+          gh pr --help
           
-          if [[ $EXIT_CODE -eq 0 ]]; then
-            echo "Successfully converted PR to draft status"
-            echo "success=true" >> $GITHUB_OUTPUT
+          # Debug: Show gh pr edit options
+          echo "gh pr edit options:"
+          gh pr edit --help
+          
+          # Try using the GraphQL API directly as a workaround
+          echo "Attempting to convert PR to draft using GraphQL API..."
+          PR_ID=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json id --jq '.id')
+          
+          if [[ -n "$PR_ID" ]]; then
+            # Use the GraphQL API to convert the PR to draft
+            QUERY='mutation ConvertToDraft($prId: ID!) { convertPullRequestToDraft(input: {pullRequestId: $prId}) { pullRequest { isDraft } } }'
+            
+            RESULT=$(gh api graphql -f query="$QUERY" -f prId="$PR_ID" 2>&1)
+            EXIT_CODE=$?
+            
+            echo "GraphQL API Result: $RESULT"
+            
+            if [[ $EXIT_CODE -eq 0 ]]; then
+              echo "Successfully converted PR to draft status via GraphQL API"
+              echo "success=true" >> $GITHUB_OUTPUT
+            else
+              echo "::error::Failed to convert PR to draft status via GraphQL API: ${RESULT}"
+              echo "success=false" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
+            echo "::error::Could not get PR ID for GraphQL conversion"
             echo "success=false" >> $GITHUB_OUTPUT
-            # Continue workflow instead of failing to allow comment step
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -22,8 +22,10 @@ jobs:
   change-to-draft:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
-    
+      issues: write
+      
     steps:
       - name: Get PR information
         id: pr_info

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -98,14 +98,13 @@ jobs:
           steps.check_pr.outputs.should_convert == 'true'
         id: convert_to_draft
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}  # Use your PAT instead of github.token
           PR_NUMBER: ${{ inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
           # The correct command to convert a PR to draft
-          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -104,7 +104,8 @@ jobs:
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # Try the gh pr ready command with --undo flag to convert to draft
+          # The correct command to convert a PR to draft
+          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           
@@ -113,33 +114,8 @@ jobs:
             echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
-            # Let's try a different approach with a REST API call
-            echo "Attempting to convert PR to draft using REST API..."
-            
-            # Get the PR node ID
-            PR_NODE_ID=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json id --jq '.id')
-            
-            if [[ -n "$PR_NODE_ID" ]]; then
-              # Use the REST API to convert the PR to draft
-              REST_RESULT=$(curl -s -X POST \
-                -H "Authorization: token $GH_TOKEN" \
-                -H "Accept: application/vnd.github.v3+json" \
-                "https://api.github.com/graphql" \
-                -d "{\"query\":\"mutation { convertPullRequestToDraft(input: {pullRequestId: \\\"$PR_NODE_ID\\\"}) { pullRequest { id } } }\"}" 2>&1)
-              
-              REST_EXIT_CODE=$?
-              
-              if [[ $REST_EXIT_CODE -eq 0 && ! "$REST_RESULT" =~ "errors" ]]; then
-                echo "Successfully converted PR to draft status via REST API"
-                echo "success=true" >> $GITHUB_OUTPUT
-              else
-                echo "::error::Failed to convert PR to draft status via REST API: ${REST_RESULT}"
-                echo "success=false" >> $GITHUB_OUTPUT
-              fi
-            else
-              echo "::error::Could not get PR ID for REST API conversion"
-              echo "success=false" >> $GITHUB_OUTPUT
-            fi
+            echo "success=false" >> $GITHUB_OUTPUT
+            # Continue workflow instead of failing to allow comment step
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -105,7 +105,7 @@ jobs:
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
           # The correct command to convert a PR to draft
-          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
+          echo $(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo)
           OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
           EXIT_CODE=$?
           
@@ -117,6 +117,7 @@ jobs:
             echo "success=false" >> $GITHUB_OUTPUT
             # Continue workflow instead of failing to allow comment step
           fi
+          echo "success=true" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Add Comment to PR

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -27,54 +27,54 @@ jobs:
       issues: write
       statuses: write
       
-      - name: Get PR information
-        id: pr_info
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: |
-          echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
-          
-          gh --version
-          
-          echo "Listing all open PRs:"
-          gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
-          
-          echo "Checking PR via API:"
-          curl -s -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
-          
-          echo "Attempting to fetch PR with gh CLI (with debugging)..."
-          set +e  # Don't exit on error
-          gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
-          PR_EXIT_CODE=$?
-          set -e  # Re-enable exit on error
-          
-          echo "gh pr view exit code: ${PR_EXIT_CODE}"
-          
-          if [[ $PR_EXIT_CODE -ne 0 ]]; then
-            echo "::error::Failed to fetch PR #${PR_NUMBER}"
-            echo "pr_exists=false" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-          
-          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
-          
-          # Print the PR data for debugging
-          echo "PR Data: ${PR_DATA}"
-          
-          # Extract PR data from json response
-          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
-          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
-          PR_URL=$(echo "$PR_DATA" | jq -r '.url')
-          
-          echo "PR #${PR_NUMBER} found. Is draft: ${IS_DRAFT}"
-          echo "pr_exists=true" >> $GITHUB_OUTPUT
-          echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
-          echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
-          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
-        shell: bash
+        - name: Get PR information
+          id: pr_info
+          env:
+            GH_TOKEN: ${{ github.token }}
+            PR_NUMBER: ${{ inputs.pr_number }}
+            GITHUB_REPOSITORY: ${{ github.repository }}
+          run: |
+            echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
+            
+            gh --version
+            
+            echo "Listing all open PRs:"
+            gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
+            
+            echo "Checking PR via API:"
+            curl -s -H "Authorization: token ${GH_TOKEN}" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
+            
+            echo "Attempting to fetch PR with gh CLI (with debugging)..."
+            set +e  # Don't exit on error
+            gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
+            PR_EXIT_CODE=$?
+            set -e  # Re-enable exit on error
+            
+            echo "gh pr view exit code: ${PR_EXIT_CODE}"
+            
+            if [[ $PR_EXIT_CODE -ne 0 ]]; then
+              echo "::error::Failed to fetch PR #${PR_NUMBER}"
+              echo "pr_exists=false" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+            
+            PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
+            
+            # Print the PR data for debugging
+            echo "PR Data: ${PR_DATA}"
+            
+            # Extract PR data from json response
+            IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
+            PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+            PR_URL=$(echo "$PR_DATA" | jq -r '.url')
+            
+            echo "PR #${PR_NUMBER} found. Is draft: ${IS_DRAFT}"
+            echo "pr_exists=true" >> $GITHUB_OUTPUT
+            echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
+            echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+            echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
+          shell: bash
         
       - name: Check if PR should be converted to draft
         id: check_pr

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -110,6 +110,8 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
             -d '{"draft":true}')
+
+          echo "$RESPONSE"
           
           # Check if the update was successful
           UPDATED_DRAFT=$(echo "$RESPONSE" | jq -r '.draft')

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -27,7 +27,6 @@ jobs:
       issues: write
       statuses: write
       
-    steps:
       - name: Get PR information
         id: pr_info
         env:
@@ -36,20 +35,31 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           echo "Fetching metadata for PR #${PR_NUMBER} in repository ${GITHUB_REPOSITORY}..."
+          
           gh --version
           
-          echo "Attempting to fetch PR with explicit repository..."
-          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url 2>&1)
-          PR_EXIT_CODE=$?
+          echo "Listing all open PRs:"
+          gh pr list --repo ${GITHUB_REPOSITORY} --limit 5
           
-          echo "Command output: ${PR_DATA}"
-          echo "Exit code: ${PR_EXIT_CODE}"
+          echo "Checking PR via API:"
+          curl -s -H "Authorization: token ${GH_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" | jq '.number, .draft, .state'
+          
+          echo "Attempting to fetch PR with gh CLI (with debugging)..."
+          set +e  # Don't exit on error
+          gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url
+          PR_EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+          
+          echo "gh pr view exit code: ${PR_EXIT_CODE}"
           
           if [[ $PR_EXIT_CODE -ne 0 ]]; then
-            echo "::error::Failed to fetch PR #${PR_NUMBER}: ${PR_DATA}"
+            echo "::error::Failed to fetch PR #${PR_NUMBER}"
             echo "pr_exists=false" >> $GITHUB_OUTPUT
             exit 1
           fi
+          
+          PR_DATA=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json number,draft,author,url)
           
           # Print the PR data for debugging
           echo "PR Data: ${PR_DATA}"
@@ -65,7 +75,7 @@ jobs:
           echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
           echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
         shell: bash
-
+        
       - name: Check if PR should be converted to draft
         id: check_pr
         if: steps.pr_info.outputs.pr_exists == 'true' && steps.pr_info.outputs.is_draft == 'false'

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
         shell: bash
 
-      - name: Change PR to Draft
+      - name: Change PR to Draft # and do that via the API because the default token can't with the gh CLI
         if: >-
           steps.pr_info.outputs.pr_exists == 'true' && 
           steps.pr_info.outputs.is_draft == 'false' && 
@@ -104,18 +104,22 @@ jobs:
         run: |
           echo "Converting PR #${PR_NUMBER} to draft status..."
           
-          # The correct command to convert a PR to draft
-          gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo
-          OUTPUT=$(gh pr ready ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --undo 2>&1)
-          EXIT_CODE=$?
+          # Use REST API instead of gh pr ready --undo
+          RESPONSE=$(curl -s -X PATCH \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            -d '{"draft":true}')
           
-          if [[ $EXIT_CODE -eq 0 ]]; then
+          # Check if the update was successful
+          UPDATED_DRAFT=$(echo "$RESPONSE" | jq -r '.draft')
+          
+          if [[ "$UPDATED_DRAFT" == "true" ]]; then
             echo "Successfully converted PR to draft status"
             echo "success=true" >> $GITHUB_OUTPUT
           else
-            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
+            echo "::error::Failed to convert PR to draft status: $(echo "$RESPONSE" | jq -r '.message')"
             echo "success=false" >> $GITHUB_OUTPUT
-            # Continue workflow instead of failing to allow comment step
           fi
         shell: bash
 

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -1,0 +1,145 @@
+name: Change PR to Draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR Number to convert to draft'
+        required: true
+        type: string
+      skip_label_check:
+        description: 'Skip checking for exemption labels'
+        required: false
+        type: boolean
+        default: false
+      comment_on_pr:
+        description: 'Add a comment explaining the draft conversion'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  change-to-draft:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - name: Get PR information
+        id: pr_info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "Fetching metadata for PR #${PR_NUMBER}..."
+          
+          # Check if PR exists and get its current status
+          PR_DATA=$(gh pr view ${PR_NUMBER} --json number,draft,author,url 2>&1)
+          if [[ $? -ne 0 ]]; then
+            echo "::error::Failed to fetch PR #${PR_NUMBER}: ${PR_DATA}"
+            echo "pr_exists=false" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          
+          # Extract PR data from json response
+          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
+          PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author.login')
+          PR_URL=$(echo "$PR_DATA" | jq -r '.url')
+          
+          echo "PR #${PR_NUMBER} found. Is draft: ${IS_DRAFT}"
+          echo "pr_exists=true" >> $GITHUB_OUTPUT
+          echo "is_draft=${IS_DRAFT}" >> $GITHUB_OUTPUT
+          echo "pr_author=${PR_AUTHOR}" >> $GITHUB_OUTPUT
+          echo "pr_url=${PR_URL}" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Check if PR should be converted to draft
+        id: check_pr
+        if: steps.pr_info.outputs.pr_exists == 'true' && steps.pr_info.outputs.is_draft == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          SKIP_LABEL_CHECK: ${{ inputs.skip_label_check }}
+        run: |
+          # Skip label check if requested
+          if [[ "$SKIP_LABEL_CHECK" == "true" ]]; then
+            echo "Skipping exemption label check as requested"
+            echo "should_convert=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Check for labels that would exclude this PR from being converted to draft
+          echo "Checking PR #${PR_NUMBER} for exclusion labels..."
+          
+          # Use jq to check for specific labels
+          EXEMPT_LABEL=$(gh pr view ${PR_NUMBER} --json labels \
+            --jq '.labels | map(select(.name == "no-auto-draft")) | length')
+          
+          if [[ "$EXEMPT_LABEL" -gt 0 ]]; then
+            echo "Skipping draft conversion due to exemption label"
+            echo "should_convert=false" >> $GITHUB_OUTPUT
+          else
+            echo "No exemption labels found, will convert PR to draft"
+            echo "should_convert=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Change PR to Draft
+        if: >-
+          steps.pr_info.outputs.pr_exists == 'true' && 
+          steps.pr_info.outputs.is_draft == 'false' && 
+          steps.check_pr.outputs.should_convert == 'true'
+        id: convert_to_draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "Converting PR #${PR_NUMBER} to draft status..."
+          
+          # Attempt to convert PR to draft and capture output
+          OUTPUT=$(gh pr ready ${PR_NUMBER} --draft 2>&1)
+          EXIT_CODE=$?
+          
+          if [[ $EXIT_CODE -eq 0 ]]; then
+            echo "Successfully converted PR to draft status"
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
+            echo "success=false" >> $GITHUB_OUTPUT
+            # Continue workflow instead of failing to allow comment step
+          fi
+        shell: bash
+
+      - name: Add Comment to PR
+        if: >-
+          inputs.comment_on_pr == true && 
+          steps.pr_info.outputs.pr_exists == 'true' && 
+          steps.convert_to_draft.outputs.success == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_AUTHOR: ${{ steps.pr_info.outputs.pr_author }}
+        run: |
+          # Add a helpful comment explaining why the PR was changed to draft
+          COMMENT="Hi @${PR_AUTHOR}, this PR has been automatically converted to draft status.
+          When you're ready for review again, please mark it as 'Ready for review'.
+          
+          If you want to prevent this behavior for this PR please add a `no-auto-draft` label to this PR.
+          *This is an automated action by a CI workflow.*"
+          
+          gh pr comment ${PR_NUMBER} --body "$COMMENT"
+        shell: bash
+
+      - name: Notify on conversion failure
+        if: >-
+          inputs.comment_on_pr == true && 
+          steps.pr_info.outputs.pr_exists == 'true' && 
+          steps.convert_to_draft.outputs.success == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "⚠️ Draft Conversion Failed"
+          echo "The system attempted to convert this PR to draft status but encountered an error."
+          exit 1
+        shell: bash

--- a/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
+++ b/.github/workflows/reusable-auto-convert-PR-to-draft.yaml
@@ -111,12 +111,13 @@ jobs:
           
           if [[ $EXIT_CODE -eq 0 ]]; then
             echo "Successfully converted PR to draft status"
-            echo "success=true" >> $GITHUB_OUTPUT
+            #echo "success=true" >> $GITHUB_OUTPUT
           else
             echo "::error::Failed to convert PR to draft status: ${OUTPUT}"
-            echo "success=false" >> $GITHUB_OUTPUT
+            #echo "success=false" >> $GITHUB_OUTPUT
             # Continue workflow instead of failing to allow comment step
           fi
+          echo THIS IS CURRENTLY BROKEN, NEEDS DIFFERENT PERMISSIONS TO WORK
           echo "success=true" >> $GITHUB_OUTPUT
         shell: bash
 

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -2,7 +2,7 @@ name: Auto PR Drafter
 
 on:
   pull_request:
-#    types: [synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   handle-new-commits:
@@ -19,7 +19,7 @@ jobs:
 
       - name: Convert PR to draft
         if: steps.check_pr_status.outputs.is_draft == 'false'
-        uses: https://github.com/NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
+        uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
         with:
           pr_number: ${{ github.event.pull_request.number }}
           skip_label_check: false

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -11,9 +11,9 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+    secrets: ${{ secrets.GITHUB_TOKEN }}
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
     with:
       pr_number: ${{ github.event.pull_request.number }}
       skip_label_check: false
       comment_on_pr: true
-    secrets: inherit

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Convert PR to draft
         if: steps.check_pr_status.outputs.is_draft == 'false'
-        uses: https://github.com/NRLMMD-GEOIPS/geoips_ci/.github/workflows/change-pr-to-draft.yml@main
+        uses: https://github.com/NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
         with:
           pr_number: ${{ github.event.pull_request.number }}
           skip_label_check: false

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -1,0 +1,26 @@
+name: Auto PR Drafter
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  handle-new-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is not draft
+        id: check_pr_status
+        run: |
+          if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
+            echo "is_draft=false" >> $GITHUB_OUTPUT
+          else
+            echo "is_draft=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Convert PR to draft
+        if: steps.check_pr_status.outputs.is_draft == 'false'
+        uses: https://github.com/NRLMMD-GEOIPS/geoips_ci/.github/workflows/change-pr-to-draft.yml@main
+        with:
+          pr_number: ${{ github.event.pull_request.number }}
+          skip_label_check: false
+          comment_on_pr: true

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -11,10 +11,9 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
     with:
       pr_number: ${{ github.event.pull_request.number }}
       skip_label_check: false
       comment_on_pr: true
+    secrets: inherit

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -11,7 +11,8 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
-    secrets: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -6,6 +6,11 @@ on:
 
 jobs:
   handle-new-commits:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: write
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
     with:
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -6,21 +6,9 @@ on:
 
 jobs:
   handle-new-commits:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if PR is not draft
-        id: check_pr_status
-        run: |
-          if [[ "${{ github.event.pull_request.draft }}" == "false" ]]; then
-            echo "is_draft=false" >> $GITHUB_OUTPUT
-          else
-            echo "is_draft=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Convert PR to draft
-        if: steps.check_pr_status.outputs.is_draft == 'false'
-        uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
-        with:
-          pr_number: ${{ github.event.pull_request.number }}
-          skip_label_check: false
-          comment_on_pr: true
+    uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-auto-convert-PR-to-draft.yaml@29-convert-prs-to-draft-after-every-commit-on-an-open-pr
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      skip_label_check: false
+      comment_on_pr: true
+    secrets: inherit

--- a/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
+++ b/.github/workflows/ruleset-auto-mark-as-draft-after-new-commit.yaml
@@ -2,7 +2,7 @@ name: Auto PR Drafter
 
 on:
   pull_request:
-    types: [synchronize]
+#    types: [synchronize]
 
 jobs:
   handle-new-commits:

--- a/docs/source/releases/latest/29-convert-prs-to-draft-after-every-commit-on-an-open-pr.yaml
+++ b/docs/source/releases/latest/29-convert-prs-to-draft-after-every-commit-on-an-open-pr.yaml
@@ -1,0 +1,126 @@
+bug fix:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+enhancement:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+deprecation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+removal:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+performance:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+documentation:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null
+continuous integration:
+- title: ''
+  description: ''
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - ''
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null


### PR DESCRIPTION
This PR sets PRs that it's enabled on to "draft" after every new commit and posts a comment to let the opener know what's happening. 

It allows the use of a `no-auto-draft` label to disable this. 

It is currently non-functional as it needs a personal access token or an app token setup. Please review it and see if it would be worth setting that up.

Produces comments like this:

![Screenshot 2025-04-30 at 4 14 40 PM](https://github.com/user-attachments/assets/25407a56-b713-40b9-a012-77f23981ba4f)
