### PR TITLE
Update ruleset-doc-test.yaml - fix logic error

### DIFF
--- a/.github/workflows/ruleset-doc-test.yaml
+++ b/.github/workflows/ruleset-doc-test.yaml
@@ -37,8 +37,8 @@ jobs:
     # are not pip installable, so do not attempt to run.
     if: >
       !contains(github.event.repository.name, 'test_data_') &&
-      !github.event.repository.name == 'geoips_ci' &&
-      !github.event.repository.name == '.github'
+      github.event.repository.name != 'geoips_ci' &&
+      github.event.repository.name != '.github'
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/ruleset-doc-test.yaml
+++ b/.github/workflows/ruleset-doc-test.yaml
@@ -37,6 +37,7 @@ jobs:
     # are not pip installable, so do not attempt to run.
     if: >
       !contains(github.event.repository.name, 'test_data_') &&
+      github.event.repository.name != '.vscode' &&
       github.event.repository.name != 'geoips_ci' &&
       github.event.repository.name != '.github'
     permissions:


### PR DESCRIPTION
This fixes the placement of two `!`s so that the logic functions as intended in the doc-test ruleset file.