### PR TITLE
Making the Spell Check Job Non-Blocking

### DIFF
--- a/.github/workflows/reusable-cspell-spell-checking.yaml
+++ b/.github/workflows/reusable-cspell-spell-checking.yaml
@@ -38,8 +38,9 @@ jobs:
             # For pushes, check modified files in the latest commit
             git diff --name-only --diff-filter=M ${{ github.event.before }} ${{ github.sha }} | xargs -I{} sh -c 'test -f "{}" && echo "{}"' | cspell --config .cspell.json --no-progress --no-must-find-files --file-list stdin
           fi
-        
-      - name: Check spelling on new files (blocking)
+
+      - name: Check spelling on new files (non-blocking)
+        continue-on-error: true
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
             # For pull requests, check new files in the PR

--- a/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
+++ b/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
@@ -1,6 +1,6 @@
-bug fix:
-- title: 'Making the Spell Check Job Non-Blocking '
-  description: 'Making the Spell Check Job Non-Blocking.'
+ci:
+- title: 'Make the spell check CI non-blocking '
+  description: 'This allows PRs to be merged even if cspell fails. It still runs cspell for the convinience of reviewers.'
   files:
     deleted: []
     moved: []

--- a/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
+++ b/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
@@ -1,0 +1,17 @@
+bug fix:
+- title: 'Making the Spell Check Job Non-Blocking '
+  description: 'Making the Spell Check Job Non-Blocking.'
+  files:
+    deleted: []
+    moved: []
+    added:
+    - '/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml'
+    modified:
+    - '/.github/workflows/reusable-cspell-spell-checking.yaml'
+    - '/sync_external/.github/workflows/ruleset-lint.yaml'
+  related-issue:
+    number: 66
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geoips_ci'
+  date:
+    start: 2026/02/03
+    finish: 2026/02/03

--- a/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
+++ b/docs/source/releases/latest/66-make-spell-check-job-non-blocking.yaml
@@ -1,6 +1,6 @@
 ci:
 - title: 'Make the spell check CI non-blocking '
-  description: 'This allows PRs to be merged even if cspell fails. It still runs cspell for the convinience of reviewers.'
+  description: 'This allows PRs to be merged even if cspell fails. It still runs cspell for the convenience of reviewers.'
   files:
     deleted: []
     moved: []

--- a/sync_external/.github/workflows/ruleset-lint.yaml
+++ b/sync_external/.github/workflows/ruleset-lint.yaml
@@ -19,7 +19,6 @@ jobs:
       token: ${{ secrets.GITHUB_TOKEN }}
   spell-check:
     name: Spell Check Changed Files
-    continue-on-error: true
     # You do not appear to be able to use variables in the "uses" field.
     uses: NRLMMD-GEOIPS/geoips_ci/.github/workflows/reusable-cspell-spell-checking.yaml@main
     permissions:


### PR DESCRIPTION
## ✨ Summary

Making the Spell Check Job Non-Blocking.
Moving the `continue-on-error: true` parameter from the incorrect position in `/sync_external/.github/workflows/ruleset-lint.yaml` to the correct position in `/.github/workflows/reusable-cspell-spell-checking.yaml`

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [X] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
- [X] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** NRLMMD-GEOIPS/geoips_ci#66
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

💖🌟🌎🌟💖
