### PR TITLE
Remove fromJSON from runner configuration in reusable-doc-test.yaml

### DIFF
--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -116,7 +116,8 @@ jobs:
       needs.get-job-flags.outputs.CI_BUILD_SPHINX_HTML == 'true' &&
       (needs.get-doclinttest-image.result == 'success' ||
       needs.get-doclinttest-image.result == 'skipped')
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    # runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    runs-on: ${{ vars.RUNNER }}
     needs: [get-doclinttest-image, get-job-flags]
     container:
       image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
@@ -178,7 +179,8 @@ jobs:
       needs.get-job-flags.outputs.CI_TEST_INTERFACES == 'true' &&
       (needs.get-doclinttest-image.result == 'success' ||
       needs.get-doclinttest-image.result == 'skipped')
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    # runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    runs-on: ${{ vars.RUNNER }}
     needs: [get-doclinttest-image, get-job-flags]
     container:
       image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
@@ -210,7 +212,8 @@ jobs:
       needs.get-job-flags.outputs.CI_TEST_PYTEST_SHORT == 'true' &&
       (needs.get-doclinttest-image.result == 'success' ||
       needs.get-doclinttest-image.result == 'skipped')
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    # runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN) || vars.RUNNER }}
+    runs-on: ${{ vars.RUNNER }}
     needs: [get-doclinttest-image, get-job-flags]
     container:
       image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}


### PR DESCRIPTION
Do not use fromJSON, because it doesn't work for a single string

