### PR TITLE
Remove fromJSON from runner configuration for build_doclinttest_image

### DIFF
--- a/.github/workflows/reusable-build-docker-image.yaml
+++ b/.github/workflows/reusable-build-docker-image.yaml
@@ -135,7 +135,8 @@ jobs:
   # installed using `pip install .[doc,lint,test]`. Scripts from geoips can be called
   # from /packages/geoips.
   build_doclinttest_image:
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN || vars.RUNNER) }}
+    # runs-on: ${{ fromJSON(vars.RUNNER_DOCKERRUN || vars.RUNNER) }}
+    runs-on: ${{ vars.RUNNER }}
     needs: get-job-flags
     if: >
       ! cancelled() &&


### PR DESCRIPTION
Do not use fromJSON because it doesn't work for a single string