### PR TITLE
Add variables to control failure modes for unit and integration tests

### DIFF
--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Lint and unit tests
         id: lint
-        continue-on-error: ${{ continue_on_core_unit_error }}
+        continue-on-error: ${{ inputs.continue_on_core_unit_error }}
         env:
           CI_LINT: ${{ vars.CI_LINT }}
           PACKAGE_NAME_ENV: ${{ env.PACKAGE_NAME }}
@@ -260,7 +260,7 @@ jobs:
 
       - name: Core unit tests (plugin repos)
         if: ${{ env.CI_DEBUG_FAST != 'true' && env.IS_PLUGIN == 'true' && inputs.run_core_tests }}
-        continue-on-error: ${{ continue_on_plugins_unit_error }}
+        continue-on-error: ${{ inputs.continue_on_plugins_unit_error }}
         run: |
           docker run --rm \
             --user root \

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -451,7 +451,7 @@ jobs:
 
       - name: Run plugin integration tests
         if: ${{ always() && env.IS_PLUGIN != 'true' && vars.CI_INTEGRATION != 'false' }}
-        continue-on-error: ${{ inputs.contiune_on_plugins_integ_error }}
+        continue-on-error: ${{ inputs.continue_on_plugins_integ_error }}
         env:
           CI_DOCKER_USER: ${{ vars.CI_DOCKER_USER }}
         run: |

--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -18,6 +18,26 @@ on:
         required: false
         type: boolean
         default: true
+      continue_on_core_unit_error:
+        description: "Ignore errors in core GeoIPS unit tests"
+        required: false
+        type: boolean
+        default: false
+      continue_on_plugins_unit_error:
+        description: "Ignore failues in plugin packages unit tests"
+        required: false
+        type: boolean
+        default: false
+      continue_on_core_integ_error:
+        description: "Ignore errors in core GeoIPS integration tests"
+        required: false
+        type: boolean
+        default: false
+      continue_on_plugins_integ_error:
+        description: "Ignore failues in plugin packages integration tests"
+        required: false
+        type: boolean
+        default: false
     secrets:
       token:
         required: false
@@ -192,6 +212,7 @@ jobs:
 
       - name: Lint and unit tests
         id: lint
+        continue-on-error: ${{ continue_on_core_unit_error }}
         env:
           CI_LINT: ${{ vars.CI_LINT }}
           PACKAGE_NAME_ENV: ${{ env.PACKAGE_NAME }}
@@ -239,6 +260,7 @@ jobs:
 
       - name: Core unit tests (plugin repos)
         if: ${{ env.CI_DEBUG_FAST != 'true' && env.IS_PLUGIN == 'true' && inputs.run_core_tests }}
+        continue-on-error: ${{ continue_on_plugins_unit_error }}
         run: |
           docker run --rm \
             --user root \
@@ -373,6 +395,7 @@ jobs:
 
       - name: Run integration tests
         if: ${{ vars.CI_INTEGRATION != 'false' }}
+        continue-on-error: ${{ inputs.continue_on_core_integ_error }}
         env:
           CI_DOCKER_USER: ${{ vars.CI_DOCKER_USER }}
           PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
@@ -428,6 +451,7 @@ jobs:
 
       - name: Run plugin integration tests
         if: ${{ always() && env.IS_PLUGIN != 'true' && vars.CI_INTEGRATION != 'false' }}
+        continue-on-error: ${{ inputs.contiune_on_plugins_integ_error }}
         env:
           CI_DOCKER_USER: ${{ vars.CI_DOCKER_USER }}
         run: |

--- a/docs/source/releases/latest/test-failure-modes.yaml
+++ b/docs/source/releases/latest/test-failure-modes.yaml
@@ -15,5 +15,5 @@ enhancement:
     number: null
     repo_url: ''
   date:
-    start: 20260706
-    finish: 20260706
+    start: 2026-07-06
+    finish: 2026-07-06

--- a/docs/source/releases/latest/test-failure-modes.yaml
+++ b/docs/source/releases/latest/test-failure-modes.yaml
@@ -6,11 +6,8 @@ enhancement:
     but are currently used to ignore the failing plugin package integration
     tests since these tests only fail in CI and not locally.
   files:
-    added:
     modified:
     - '.github/workflows/reusable-ci.yaml'
-    deleted:
-    moved:
   related-issue:
     number: null
     repo_url: ''

--- a/docs/source/releases/latest/test-failure-modes.yaml
+++ b/docs/source/releases/latest/test-failure-modes.yaml
@@ -1,0 +1,19 @@
+enhancement:
+- title: 'Add switches for test failure modes'
+  description: |
+    Add four switches to allow unit tests and integration tests to fail
+    but still pass the workflow as a whole. These are set to `false` by default
+    but are currently used to ignore the failing plugin package integration
+    tests since these tests only fail in CI and not locally.
+  files:
+    added:
+    modified:
+    - '.github/workflows/reusable-ci.yaml'
+    deleted:
+    moved:
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 20260706
+    finish: 20260706


### PR DESCRIPTION
## ✨ Summary

This PR adds the following variables to control test failure modes:

- continue_on_core_integ_error
- continue_on_core_unit_error
- continue_on_plugins_integ_error
- continue_on_plugins_unit_error

These all default to `false`. They can be set to `true` in calling workflows to allow unit or integration tests to fail for either core GeoIPS or its plugin packages.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---

## 🧪 Testing Instructions

This should work with geoips#1261


💖🌟🌎🌟💖
