### PR TITLE
Modify docs build command to specify output directory

### DIFF
--- a/.github/workflows/reusable-deploy-docs.yaml
+++ b/.github/workflows/reusable-deploy-docs.yaml
@@ -135,7 +135,11 @@ jobs:
           export GEOIPS_OUTDIRS=""
           export GEOIPS_TESTDATA_DIR="" # necessary for GeoIPS to be importable for the docs to build. Just has to be set to *something*
           ln -s ./geoips_default_branch ./geoips # the CLI *requires* the geoips folder to be named "geoips" so soft linking here
-          python3 ./geoips_default_branch/docs/build_docs.py --geoips-docs-path ./geoips_default_branch/docs --repo-path ./current_repo_current_branch "$curr_repo" 
+          python3 ./geoips_default_branch/docs/build_docs.py \
+            --geoips-docs-path ./geoips_default_branch/docs \
+            --output-dir "./current_repo_current_branch/docs/build/sphinx/html" \
+            --repo-path ./current_repo_current_branch \
+            "$curr_repo" 
           ret=$?
           rm -f ./geoips
           if [[ "${ret##*:}" != *"0"* ]]; then

--- a/docs/source/releases/latest/specify-build-docs-output-path.yaml
+++ b/docs/source/releases/latest/specify-build-docs-output-path.yaml
@@ -1,0 +1,15 @@
+enhancement:
+- title: 'Add docs output path to build docs command'
+  description: |
+    deploy_pages.sh requires docs to live in docs/build,
+    specify explicit output path for build docs command
+    in deploy docs CI.
+  files:
+    modified:
+    - '.github/workflows/reusable-deploy-docs.yaml'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 2026-07-07
+    finish: 2026-07-07


### PR DESCRIPTION
Updated the build_docs.py command to include output directory. This is the required Location for deploy_pages.sh

