### PR TITLE
Add pytest plugins to lint

### DIFF
--- a/.github/workflows/reusable-lint.yaml
+++ b/.github/workflows/reusable-lint.yaml
@@ -98,8 +98,8 @@ jobs:
         with:
           fetch-depth: 0
           path: ./current_repo_current_branch
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install pytest and plugins
+        run: pip install pytest pytest-cov pytest-mock pytest-xdist
       - name: Checkout geoips default branch
         uses: actions/checkout@v4
         with:

--- a/docs/source/releases/latest/add-pytest-plugins-to-lint.yaml
+++ b/docs/source/releases/latest/add-pytest-plugins-to-lint.yaml
@@ -1,0 +1,20 @@
+bug fix:
+- title: 'Add pytest plugins to install'
+  description: |
+    Testing requires multiple plugins to succeed. This PR adds
+    pytest-cov, pytest-mock, and pytest-xdist.
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - '.github/workflows/reusable-lint.yaml'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 2026-07-08
+    finish: 2026-07-08


### PR DESCRIPTION
## ✨ Summary

Add pytest-cov, pytest-mock, and pytest-xdist to install step for linting.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---



## 🔗 Related Issues

- **Fixes:** `NRLMMD-GEOIPS/geoips#NNN`  
  <!-- You can point to multiple issues or issues in another repository if needed! -->

---

💖🌟🌎🌟💖
