### PR TITLE
Upgrade GitHub Actions to version 7

### DIFF
--- a/.github/workflows/reusable-doc-test.yaml
+++ b/.github/workflows/reusable-doc-test.yaml
@@ -125,7 +125,7 @@ jobs:
       CURR_REPO: ${{ github.event.repository.name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure Git safe directory
         run: git config --global --add safe.directory $PWD
@@ -164,7 +164,7 @@ jobs:
           echo "BUILT_DOCS_PATH=$PWD/build/sphinx/html" >> $GITHUB_OUTPUT
       - name: Upload HTML Docs
         if: ${{ vars.UPLOAD_GITHUB_ARTIFACTS == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: HTML Docs
           path: ${{ steps.build-html-docs.outputs.BUILT_DOCS_PATH }}
@@ -186,7 +186,7 @@ jobs:
       image: ${{ needs.get-job-flags.outputs.DOCKER_IMAGE_NAME }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Configure Git safe directory
         run: git config --global --add safe.directory $PWD
       - name: Pip install package
@@ -221,7 +221,7 @@ jobs:
       CURR_REPO: ${{ github.event.repository.name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Configure Git safe directory
         run: git config --global --add safe.directory $PWD
       - name: Pip install package

--- a/docs/source/releases/latest/node20-24.yaml
+++ b/docs/source/releases/latest/node20-24.yaml
@@ -1,0 +1,12 @@
+bug fix:
+- title: 'Fix failing NodeJS 20.* dependency'
+  description: 'This updates the node version of the checkout steps to no longer depend on node 20.* which has now been deprecated by GitHub.'
+  files:
+    modified:
+    - '.github/workflows/reusable-doc-test.yaml'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: null
+    finish: null


### PR DESCRIPTION
Updated actions/checkout and actions/upload-artifact to version 7. Fix issues with checkout permissions and node deprecation: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/